### PR TITLE
feat: Add back computer with GSAP animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Silicon Circle</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
 </head>
 <body>
     <audio id="boot-sound" src="https://www.soundjay.com/buttons/sounds/button-1.mp3" preload="auto"></audio>

--- a/script.js
+++ b/script.js
@@ -12,7 +12,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const terminalOutput = document.querySelector('.terminal-output');
     const fixedComputerDisplay = document.querySelector('.fixed-computer-display');
     const pageWrapper = document.querySelector('.page-wrapper');
+    const powerLight = document.querySelector('.power-light');
 
+    gsap.to(powerLight, {
+        backgroundColor: '#33ff33',
+        duration: 1,
+        repeat: -1,
+        yoyo: true,
+        ease: 'power1.inOut'
+    });
     // Hide splash screen after a delay and play sound
     setTimeout(() => {
         splashScreen.classList.add('hidden');
@@ -74,39 +82,43 @@ document.addEventListener('DOMContentLoaded', () => {
             const computerHeight = fixedComputerDisplay.offsetHeight;
             const viewportHeight = window.innerHeight;
 
-            // The computer should start scrolling away when the top of the FAQ section is about to enter the viewport.
-            // We subtract the computer's height to ensure it's completely gone before the FAQ section is visible.
             const unstickScrollPosition = faqSectionTop - viewportHeight;
 
             if (window.scrollY < statsSectionTop) {
                 // On hero section: hidden
-                fixedComputerDisplay.classList.remove('active-scroll', 'locked', 'scrolling-away');
-                pageWrapper.classList.remove('computer-active');
-                fixedComputerDisplay.style.position = 'fixed';
-                fixedComputerDisplay.style.top = '100vh'; // Position it below the viewport
+                gsap.to(fixedComputerDisplay, {
+                    right: '-700px',
+                    opacity: 0,
+                    duration: 0.8,
+                    ease: 'power2.out',
+                    onComplete: () => {
+                        pageWrapper.classList.remove('computer-active');
+                    }
+                });
             } else if (window.scrollY >= statsSectionTop && window.scrollY < unstickScrollPosition) {
                 // After hero, before unstick point (FAQ): fixed in center
-                fixedComputerDisplay.classList.add('active-scroll', 'locked');
-                fixedComputerDisplay.classList.remove('scrolling-away');
                 pageWrapper.classList.add('computer-active');
-                fixedComputerDisplay.style.position = 'fixed';
-                fixedComputerDisplay.style.top = '50%';
+                gsap.to(fixedComputerDisplay, {
+                    right: '50px',
+                    opacity: 1,
+                    duration: 0.8,
+                    ease: 'power2.out',
+                    rotation: 0
+                });
             } else {
                 // After unstick point (at or after FAQ): scrolls away
-                fixedComputerDisplay.classList.add('scrolling-away');
-                fixedComputerDisplay.classList.remove('locked');
-                // The transitionend event will handle removing 'computer-active' from the page wrapper
+                gsap.to(fixedComputerDisplay, {
+                    right: '-700px',
+                    opacity: 0,
+                    duration: 0.8,
+                    ease: 'power2.in',
+                    onComplete: () => {
+                        pageWrapper.classList.remove('computer-active');
+                    }
+                });
             }
         }
     };
-
-    // Listen for the end of the computer display's transition
-    fixedComputerDisplay.addEventListener('transitionend', (event) => { // Added event parameter
-        // Ensure we only act when the 'right' property transition ends
-        if (event.propertyName === 'right' && fixedComputerDisplay.classList.contains('scrolling-away')) {
-            pageWrapper.classList.remove('computer-active');
-        }
-    });
 
     // Initial call and scroll event listener
     // Check if it's index.html or other pages

--- a/style.css
+++ b/style.css
@@ -233,7 +233,6 @@ main {
     flex-direction: column;
     align-items: center;
     filter: drop-shadow(0 0 5px rgba(51, 255, 51, 0.3)); /* Further reduced green glow */
-    transition: right 0.8s ease-out, opacity 0.5s ease-out; /* Transition for right and opacity */
     pointer-events: none; /* Default to none, overridden when active */
 }
 
@@ -248,7 +247,6 @@ main {
     right: -700px; /* Slide off to the right */
     opacity: 0; /* Fade out as it slides */
     pointer-events: none; /* Disable interaction when hidden */
-    transition: right 0.8s ease-out, opacity 0.8s ease-out; /* Transition both right and opacity */
     transform: translateY(-50%); /* Keep vertical centering */
 }
 
@@ -400,12 +398,6 @@ section h1, section h2 {
     left: 20px;
     border: 1px solid #000;
     box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #000;
-    animation: pulse 2s infinite;
-}
-
-@keyframes pulse {
-    0%, 100% { background-color: #00ff00; }
-    50% { background-color: #33ff33; }
 }
 
 .dvd-tray {


### PR DESCRIPTION
This commit replaces the existing CSS transition-based animations for the computer element with more dynamic GSAP animations.

- The GSAP library has been integrated into the project.
- The `script.js` file has been updated to use GSAP for animating the computer's appearance and disappearance based on scroll position.
- The computer's power light now has a GSAP-powered pulsing animation.
- The CSS transitions for the computer have been removed to avoid conflicts with GSAP.
- The changes have been visually verified using a Playwright script.